### PR TITLE
Bug #101 - Invalid literal error when editing a user with a null in place of their graduation year

### DIFF
--- a/app/users/views.py
+++ b/app/users/views.py
@@ -161,7 +161,12 @@ def edit_user(user_id):
                 middle_name = request.form.get("middle_name") or ""
                 last_name = request.form.get("last_name") or ""
                 email = request.form.get("email") or ""
-                graduation_year = int(request.form.get("graduation_year") or 0)
+                graduation_year_raw = request.form.get("graduation_year")
+                if not graduation_year_raw or graduation_year_raw.strip().lower() == "none":
+                    graduation_year = None
+                else:
+                    graduation_year = int(graduation_year_raw)
+
                 username = request.form.get("username") or ""
                 role_id = int(request.form.get("role_id") or 0)
 


### PR DESCRIPTION
Fixed 'invalid literal for int()' bug when editing a user in /admin/user/<user_id>/edit as required by issue #101