### PR TITLE
Dual flash messages bug fix

### DIFF
--- a/app/home/templates/home/index.html
+++ b/app/home/templates/home/index.html
@@ -55,18 +55,6 @@
             </div>
         </div>
     </div>
-    
-    </div>
-        <!-- Flash Messages -->
-        {% with messages = get_flashed_messages() %}
-          {% if messages %}
-            <ul class="flashes">
-              {% for message in messages %}
-                <li>{{ message }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        {% endwith %}
-    </div>
+
 
 {% endblock %}


### PR DESCRIPTION
Two flash messages were being displayed on the home page after logging out, this was because of the flash messages class being called twice: once in home/templates/index.html, and once in app/templates/base.html. I removed the instance in index.html to resolve the issue. 